### PR TITLE
Updated pyinstaller cmd example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Once the script is comipled and ran it will collect the following:
 ###COMPILING
 The script can be compiled using PyInstaller, using the following syntax:  
 ```python
-  python pyinstaller --onefile USB_Drop_Callback.py
+  python pyinstaller -w --onefile USB_Drop_Callback.py
 ```
+The '-w' flag prevents a cmd window from opening upon execution.
 ###USAGE
 The compiled executable is then placed on the USBs to be dropped.  Other measures can be taken to make the files look more authentic, such as:
   - Change file name to something such as "Client Name - Salary Trends.xlsx," etc. and add multiple spaces after the 'false extension" to hide the ".exe."


### PR DESCRIPTION
Included '-w' flag as a recommended setting to prevent a cmd window from opening upon execution.